### PR TITLE
Use difftool.$(git.tool).path to determine external difftool

### DIFF
--- a/git-diffall
+++ b/git-diffall
@@ -188,7 +188,11 @@ done < "$tmp"/filelist
 
 cd "$tmp"
 TOOL=$(git config --get diff.tool)
-"$(git config --get difftool.$TOOL.path)" "$left_dir" "$right_dir"
+DIFFTOOL=$(git config --get difftool.$TOOL.path)
+if [ -z "$DIFFTOOL" ]; then
+	DIFFTOOL=$TOOL
+fi
+"$DIFFTOOL" "$left_dir" "$right_dir"
 
 # On exit, remove the tmp directory
 cleanup () {


### PR DESCRIPTION
In newer git, you can set diff.tool and difftool.$(diff.tool).path in order to have many external difftools simultaneously. My patch support this new configuration.
Care to pull?
