### PR TITLE
Use bash instead of sh.

### DIFF
--- a/git-diffall
+++ b/git-diffall
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # Copyright 2010 - 2011, Tim Henigan <tim.henigan@gmail.com>
 #
 # Perform a directory diff between commits in the repository using


### PR DESCRIPTION
If you use /bin/sh on ubuntu you get the dash shell instead of bash shell. This causes git_merge_tool_path to fail. The error isn't trapped, so it exits without displaying anything and without cleaning up.
