### PR TITLE
copy-back only where files diff

### DIFF
--- a/git-diffall
+++ b/git-diffall
@@ -253,9 +253,17 @@ then
 	while read file
 	do
 		copy_target="$git_top_dir/${file#$tmp/$right_dir/}"
-		diff -pN "$copy_target" "$file"
-		if [ $? -ne 0 ]; then
-		  cp "$file" "$copy_target"
+		if test -f "$copy_target"
+		then 
+			diff -p "$copy_target" "$file"
+			should_cp=$?
+		else
+			echo "copy-back: $copy_target: Missing file is copied back"
+			should_cp=1
+		fi
+		if test $should_cp -ne 0 
+		then
+			cp "$file" "$copy_target"
 		fi
 	done
 fi


### PR DESCRIPTION
Hello. Thanks for a great script! I have the following contributions:
- avoiding superfluous copies-back which Xcode would still 
  handle as file modification events
- output copy-back diff to console, which is useful to show
  changes made in diff tool which are copied-back; but also to
  show any changes made in working_tree since diffall started
  which are overwritten by copy-back
