### PR TITLE
Use /bin/bash in shebang line.

### DIFF
--- a/git-diffall
+++ b/git-diffall
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2010 - 2012, Tim Henigan <tim.henigan@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
Since this script uses bash-specific features that are not supported by Bourne shell, such as $() for command substitution, it's more appropriate to use /bin/bash in the shebang since not all environments link /bin/sh to bash.
