### PR TITLE
README: mention "git difftool --dir-diff"

### DIFF
--- a/README
+++ b/README
@@ -29,3 +29,7 @@ This script is based on an example provided by Thomas Rast on the
 Git list [1]:
 
 [1] http://thread.gmane.org/gmane.comp.version-control.git/124807
+
+Note: The functionality provided by git-diffall has been contributed to Git
+itself and can be accessed through the "git difftool --dir-diff" command
+in Git versions v1.7.11 and newer.


### PR DESCRIPTION
Redirect new users to the "git difftool --dir-diff" Git builtin.

Recent work in git-mergetool--lib.sh could have impacted "diffall", so
encourage users to migrate to the Git version without explicitly saying
that the tool is deprecated.

Signed-off-by: David Aguilar <davvid@gmail.com>